### PR TITLE
BLOBBASEFEE returns 1 on ECOTONE

### DIFF
--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
@@ -615,7 +615,9 @@ These operators make queries about the current execution state.
     rule <k> GASPRICE    => GasPrice()                           ~> #push ... </k>
     rule <k> GASLIMIT    => GasLimit()                           ~> #push ... </k>
     rule <k> BASEFEE     => BaseFee()                            ~> #push ... </k>
-    rule <k> BLOBBASEFEE => BlobBaseFee()                        ~> #push ... </k>
+    rule <k> BLOBBASEFEE => BlobBaseFee()                        ~> #push ... </k> <schedule> SCHED </schedule>
+       requires SCHED =/=K ECOTONE
+    rule <k> BLOBBASEFEE => EvmWord(1p256)                       ~> #push ... </k> <schedule> ECOTONE </schedule>
 
     syntax NullStackOp ::= "COINBASE" | "TIMESTAMP" | "NUMBER" | "DIFFICULTY" | "PREVRANDAO"
  // ----------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR implements the change in `BLOBBASEFEE` (always returning `1` instead of the value expected in the other protocols) that is needed for `ECOTONE`.

Closes Pi-Squared-Inc/pi2/issues/2810