### PR TITLE
ci: Migrate CI runner from AWS to Hetzner

### DIFF
--- a/.github/workflows/test-master-pr.yml
+++ b/.github/workflows/test-master-pr.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   blockchain-tests:
-    runs-on: [self-hosted, aws, us-east-2, m6a.4xlarge]
+    runs-on: [self-hosted, hetzner, x64]
 
     permissions:
       contents: read


### PR DESCRIPTION
Replace the AWS self-hosted runner (aws, us-east-2, m6a.4xlarge) with the Hetzner self-hosted runner (hetzner, x64).